### PR TITLE
Update battle_bot.lua

### DIFF
--- a/epgp_battle_bot/battle_bot.lua
+++ b/epgp_battle_bot/battle_bot.lua
@@ -247,11 +247,11 @@ end
 function battle_bot_announce_handler( cmd, tail )
     local channel = string.lower(tail);
     
-    if( 
-        channel ~= 'raid'
-        or channel ~= 'guild'
-        or channel ~= 'say'
-        or channel ~= 'party'
+    if not( 
+        channel == 'raid'
+        or channel == 'guild'
+        or channel == 'say'
+        or channel == 'party'
     ) then
         if( UnitInRaid('player') == nil ) then
             channel = 'say'


### PR DESCRIPTION
not send announce the selected channel
on line 250 battle_bot.lua should be used "if not" instead of "if"
like:

```
    if not( 
        channel == 'raid'
        or channel == 'guild'
        or channel == 'say'
        or channel == 'party'
    ) then
```
